### PR TITLE
use realtive dir - current dir

### DIFF
--- a/spec/rsync_spec.rb
+++ b/spec/rsync_spec.rb
@@ -9,7 +9,7 @@ describe Rsync do
       subdirs_only: true,
       logfile: File.join(FileUtils.pwd, 'spec', 'dummy_rsync_output.log')
     )
-    expect(rsync).to receive(:`).with("rsync -ri --log-file '/Users/seanhuber/Rails Apps/rsync_wrapper/spec/dummy_rsync_output.log' --size-only --prune-empty-dirs --include '*.doc' --include '*.docx' --include '*.pdf' --include '*/' --exclude '*' \"/Users/seanhuber/Rails Apps/rsync_wrapper/spec/test_src_dir\" \"/Users/seanhuber/Rails Apps/rsync_wrapper/spec/test_dest_dir\" > /dev/null 2>&1")
+    expect(rsync).to receive(:`).with("rsync -ri --log-file '#{FileUtils.pwd}/spec/dummy_rsync_output.log' --size-only --prune-empty-dirs --include '*.doc' --include '*.docx' --include '*.pdf' --include '*/' --exclude '*' \"#{FileUtils.pwd}/spec/test_src_dir\" \"#{FileUtils.pwd}/spec/test_dest_dir\" > /dev/null 2>&1")
     expect(rsync).to receive(:parse_logfile).and_return(nil)
     rsync.sync!
   end


### PR DESCRIPTION
fixed error below

```
ned:rsync_wrapper nedim$ bundle exec rake spec
/Users/nedim/.rvm/rubies/ruby-2.4.1/bin/ruby -I/Users/nedim/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.6.0/lib:/Users/nedim/.rvm/gems/ruby-2.4.1/gems/rspec-support-3.6.0/lib /Users/nedim/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.6.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
F...

Failures:

  1) Rsync executes rsync
     Failure/Error: `#{cmd}`
     
       #<Rsync:0x007fe4f9343c68 @dirs={:src_dir=>"/Users/nedim/NED/rsync_wrapper/spec/test_src_dir", :dest_dir=>"/Users/nedim/NED/rsync_wrapper/spec/test_dest_dir"}, @inclusions=["*.doc", "*.docx", "*.pdf", "*/"], @exclusions=["*"], @logfile="/Users/nedim/NED/rsync_wrapper/spec/dummy_rsync_output.log"> received :` with unexpected arguments
         expected: ("rsync -ri --log-file '/Users/seanhuber/Rails Apps/rsync_wrapper/spec/dummy_rsync_output.log' --size-...ec/test_src_dir\" \"/Users/seanhuber/Rails Apps/rsync_wrapper/spec/test_dest_dir\" > /dev/null 2>&1")
              got: ("rsync -ri --log-file '/Users/nedim/NED/rsync_wrapper/spec/dummy_rsync_output.log' --size-only --prun..._wrapper/spec/test_src_dir\" \"/Users/nedim/NED/rsync_wrapper/spec/test_dest_dir\" > /dev/null 2>&1")
     # ./lib/rsync_wrapper/rsync.rb:35:in `exec_rsync'
     # ./lib/rsync_wrapper/rsync.rb:24:in `sync!'
     # ./spec/rsync_spec.rb:14:in `block (2 levels) in <top (required)>'

Finished in 0.22433 seconds (files took 0.61102 seconds to load)
4 examples, 1 failure

Failed examples:

rspec ./spec/rsync_spec.rb:4 # Rsync executes rsync

/Users/nedim/.rvm/rubies/ruby-2.4.1/bin/ruby -I/Users/nedim/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.6.0/lib:/Users/nedim/.rvm/gems/ruby-2.4.1/gems/rspec-support-3.6.0/lib /Users/nedim/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.6.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```